### PR TITLE
BLD: Add strong run_exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Currently the main ones are:
 
 These variants have different CUDA Toolkits, and the arm-variant package is used to select between them.
 
-The default is SBSA. Select a the tegra 'arm-variant' package by installing 'arm-variant=*=tegra'.
+The default is SBSA. Select the tegra 'arm-variant' package by installing 'arm-variant=*=tegra'.
 
 
 Current build status

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,16 @@
 package:
   name: arm-variant
-  version: 1.1.0
+  version: 1.2.0
 
 build:
-  number: 1
+  number: 0
   noarch: generic
   string: "{{ arm_variant_type }}"
   track_features:
     - arm_{{ arm_variant_type }}  # [arm_variant_type != arm_variant_type_default]
+  run_exports:
+    strong:
+      - arm-variant * {{ arm_variant_type }}
 
 test:
   commands:


### PR DESCRIPTION
We need arm-variant at runtime instead of run_constrained, but we don't want to do a migration. Instead we will add run_exports to arm-variant and compiler packages. Because some CTK packages do not use the compiler package we also will add run_exports to the arm-variant package.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
